### PR TITLE
Step1 mission 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ build/
 .idea/modules.xml
 .idea/jarRepositories.xml
 .idea/compiler.xml
+.idea/git_toolbox_blame.xml
+.idea/.name
 .idea/libraries/
 *.iws
 *.iml

--- a/.idea/git_toolbox_prj.xml
+++ b/.idea/git_toolbox_prj.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GitToolBoxProjectSettings">
+    <option name="commitMessageIssueKeyValidationOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
+    <option name="commitMessageValidationEnabledOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
+  </component>
+</project>

--- a/src/main/java/io/hhplus/tdd/point/LockManager.java
+++ b/src/main/java/io/hhplus/tdd/point/LockManager.java
@@ -1,0 +1,29 @@
+package io.hhplus.tdd.point;
+
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+@Component
+public class LockManager {
+
+    private ConcurrentHashMap<Long, ReentrantLock> locks = new ConcurrentHashMap<>();
+
+    public void lock(long id) {
+        ReentrantLock lock = locks.get(id);
+        if (lock == null) {
+            lock = new ReentrantLock();
+            locks.put(id, lock);
+        }
+        lock.lock();
+    }
+
+    public void unlock(long id) {
+        ReentrantLock lock = locks.get(id);
+        if (lock == null) {
+            return;
+        }
+        lock.unlock();
+    }
+}

--- a/src/main/java/io/hhplus/tdd/point/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/PointController.java
@@ -43,7 +43,7 @@ public class PointController {
             @PathVariable long id,
             @RequestBody long amount
     ) {
-        return new UserPoint(0, 0, 0);
+        return pointService.charge(id, amount);
     }
 
     /**

--- a/src/main/java/io/hhplus/tdd/point/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/PointController.java
@@ -54,6 +54,6 @@ public class PointController {
             @PathVariable long id,
             @RequestBody long amount
     ) {
-        return new UserPoint(0, 0, 0);
+        return pointService.use(id, amount);
     }
 }

--- a/src/main/java/io/hhplus/tdd/point/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/PointController.java
@@ -1,5 +1,6 @@
 package io.hhplus.tdd.point;
 
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.*;
@@ -8,9 +9,11 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/point")
+@RequiredArgsConstructor
 public class PointController {
 
     private static final Logger log = LoggerFactory.getLogger(PointController.class);
+    private PointService pointService;
 
     /**
      * TODO - 특정 유저의 포인트를 조회하는 기능을 작성해주세요.
@@ -19,7 +22,7 @@ public class PointController {
     public UserPoint point(
             @PathVariable long id
     ) {
-        return new UserPoint(0, 0, 0);
+        return pointService.selectById(id);
     }
 
     /**

--- a/src/main/java/io/hhplus/tdd/point/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/PointController.java
@@ -32,7 +32,7 @@ public class PointController {
     public List<PointHistory> history(
             @PathVariable long id
     ) {
-        return List.of();
+        return pointService.selectAllByUserId(id);
     }
 
     /**

--- a/src/main/java/io/hhplus/tdd/point/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/PointService.java
@@ -23,7 +23,13 @@ public class PointService {
     }
 
     public UserPoint charge(long id, long amount) {
-        return new UserPoint(0, 0, 0);
+        UserPoint userPoint = userPointTable.selectById(id);
+
+        UserPoint chargedUserPoint = userPointTable.insertOrUpdate(id, userPoint.point() + amount);
+
+        pointHistoryTable.insert(id, amount, TransactionType.CHARGE, System.currentTimeMillis());
+
+        return chargedUserPoint;
     }
 
     public UserPoint use(long id, long amount) {

--- a/src/main/java/io/hhplus/tdd/point/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/PointService.java
@@ -13,6 +13,7 @@ public class PointService {
 
     private final UserPointTable userPointTable;
     private final PointHistoryTable pointHistoryTable;
+    private final LockManager lockManager;
 
     public UserPoint selectById(long id) {
         return userPointTable.selectById(id);
@@ -27,11 +28,19 @@ public class PointService {
             throw new IllegalArgumentException("충전 금액은 0보다 커야 합니다.");
         }
 
-        UserPoint userPoint = userPointTable.selectById(id);
+        lockManager.lock(id);
 
-        UserPoint chargedUserPoint = userPointTable.insertOrUpdate(id, userPoint.point() + amount);
+        UserPoint chargedUserPoint;
 
-        pointHistoryTable.insert(id, amount, TransactionType.CHARGE, System.currentTimeMillis());
+        try {
+            UserPoint userPoint = userPointTable.selectById(id);
+
+            chargedUserPoint = adjustPoint(id, userPoint.point() + amount);
+
+            pointHistoryTable.insert(id, amount, TransactionType.CHARGE, System.currentTimeMillis());
+        } finally {
+            lockManager.unlock(id);
+        }
 
         return chargedUserPoint;
     }
@@ -41,6 +50,8 @@ public class PointService {
             throw new IllegalArgumentException("사용 포인트는 0보다 커야 합니다.");
         }
 
+        lockManager.lock(id);
+
         UserPoint userPoint = userPointTable.selectById(id);
 
         long remainingPoints = userPoint.point() - amount;
@@ -49,10 +60,19 @@ public class PointService {
             throw new IllegalArgumentException("포인트가 부족합니다.");
         }
 
-        UserPoint usedUserPoint = userPointTable.insertOrUpdate(id, remainingPoints);
+        UserPoint usedUserPoint;
+        try {
+            usedUserPoint = adjustPoint(id, remainingPoints);
 
-        pointHistoryTable.insert(id, amount, TransactionType.USE, System.currentTimeMillis());
+            pointHistoryTable.insert(id, amount, TransactionType.USE, System.currentTimeMillis());
+        } finally {
+            lockManager.unlock(id);
+        }
 
         return usedUserPoint;
+    }
+
+    private UserPoint adjustPoint(long id, long amount) {
+        return userPointTable.insertOrUpdate(id, amount);
     }
 }

--- a/src/main/java/io/hhplus/tdd/point/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/PointService.java
@@ -33,6 +33,18 @@ public class PointService {
     }
 
     public UserPoint use(long id, long amount) {
-        return new UserPoint(0, 0, 0);
+        UserPoint userPoint = userPointTable.selectById(id);
+
+        long remainingPoints = userPoint.point() - amount;
+
+        if (remainingPoints < 0) {
+            throw new IllegalArgumentException("포인트가 부족합니다.");
+        }
+
+        UserPoint usedUserPoint = userPointTable.insertOrUpdate(id, remainingPoints);
+
+        pointHistoryTable.insert(id, amount, TransactionType.USE, System.currentTimeMillis());
+
+        return usedUserPoint;
     }
 }

--- a/src/main/java/io/hhplus/tdd/point/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/PointService.java
@@ -1,0 +1,32 @@
+package io.hhplus.tdd.point;
+
+import io.hhplus.tdd.database.PointHistoryTable;
+import io.hhplus.tdd.database.UserPointTable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PointService {
+
+    private final UserPointTable userPointTable;
+    private final PointHistoryTable pointHistoryTable;
+
+    public UserPoint selectById(long id) {
+        return new UserPoint(0, 0, 0);
+    }
+
+    public List<PointHistory> selectAllByUserId(long id) {
+        return List.of();
+    }
+
+    public UserPoint charge(long id, long amount) {
+        return new UserPoint(0, 0, 0);
+    }
+
+    public UserPoint use(long id, long amount) {
+        return new UserPoint(0, 0, 0);
+    }
+}

--- a/src/main/java/io/hhplus/tdd/point/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/PointService.java
@@ -37,6 +37,10 @@ public class PointService {
     }
 
     public UserPoint use(long id, long amount) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("사용 포인트는 0보다 커야 합니다.");
+        }
+
         UserPoint userPoint = userPointTable.selectById(id);
 
         long remainingPoints = userPoint.point() - amount;

--- a/src/main/java/io/hhplus/tdd/point/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/PointService.java
@@ -15,7 +15,7 @@ public class PointService {
     private final PointHistoryTable pointHistoryTable;
 
     public UserPoint selectById(long id) {
-        return new UserPoint(0, 0, 0);
+        return userPointTable.selectById(id);
     }
 
     public List<PointHistory> selectAllByUserId(long id) {

--- a/src/main/java/io/hhplus/tdd/point/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/PointService.java
@@ -19,7 +19,7 @@ public class PointService {
     }
 
     public List<PointHistory> selectAllByUserId(long id) {
-        return List.of();
+        return pointHistoryTable.selectAllByUserId(id);
     }
 
     public UserPoint charge(long id, long amount) {

--- a/src/main/java/io/hhplus/tdd/point/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/PointService.java
@@ -23,6 +23,10 @@ public class PointService {
     }
 
     public UserPoint charge(long id, long amount) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("충전 금액은 0보다 커야 합니다.");
+        }
+
         UserPoint userPoint = userPointTable.selectById(id);
 
         UserPoint chargedUserPoint = userPointTable.insertOrUpdate(id, userPoint.point() + amount);

--- a/src/main/java/io/hhplus/tdd/point/UserPoint.java
+++ b/src/main/java/io/hhplus/tdd/point/UserPoint.java
@@ -5,7 +5,14 @@ public record UserPoint(
         long point,
         long updateMillis
 ) {
-
+    public UserPoint(long id, long point, long updateMillis) {
+        if (id <= 0) {
+            throw new IllegalArgumentException("id는 양수여야 합니다.");
+        }
+        this.id = id;
+        this.point = point;
+        this.updateMillis = updateMillis;
+    }
     public static UserPoint empty(long id) {
         return new UserPoint(id, 0, System.currentTimeMillis());
     }

--- a/src/test/java/io/hhplus/tdd/PointServiceIntegrationTest.java
+++ b/src/test/java/io/hhplus/tdd/PointServiceIntegrationTest.java
@@ -1,0 +1,46 @@
+package io.hhplus.tdd;
+
+import io.hhplus.tdd.point.PointService;
+import io.hhplus.tdd.point.UserPoint;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@SpringBootTest
+public class PointServiceIntegrationTest {
+
+    @Autowired
+    private PointService pointService;
+
+
+    @Test
+    void 충전_100번_테스트() throws InterruptedException {
+
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        int point = 100;
+
+        for(int i = 0; i< threadCount; i++){
+            executorService.submit(() -> {
+                try {
+                    pointService.charge(1L, point);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+        executorService.shutdown();
+
+        //then
+        UserPoint userPoint = pointService.selectById(1L);
+        Assertions.assertEquals(threadCount * point, userPoint.point())  ;
+    }
+}

--- a/src/test/java/io/hhplus/tdd/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/PointServiceTest.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
 
 @ExtendWith(MockitoExtension.class)
@@ -96,6 +97,18 @@ public class PointServiceTest {
         assertEquals(insertedPointHistory.updateMillis(), returnPointHistories.get(0).updateMillis());
     }
 
-    
+    @Test
+    @DisplayName("회원 포인트 사용시 잔여 포인트가 부족할 때 에러 발생")
+    void 잔여_포인트_없어서_에러_발생() {
+        long id = 1L;
+        long amount = 100L;
+        long updateMillis = 0L;
+
+        UserPoint userPoint = new UserPoint(id, amount, updateMillis);
+
+        doReturn(userPoint).when(userPointTable).selectById(1L);
+
+        assertThrows(IllegalArgumentException.class, () -> pointService.use(id, amount + 1L));
+    }
 
 }

--- a/src/test/java/io/hhplus/tdd/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/PointServiceTest.java
@@ -145,6 +145,7 @@ public class PointServiceTest {
         assertEquals(insertedPointHistory2.type(), returnPointHistories.get(1).type());
         assertEquals(insertedPointHistory2.updateMillis(), returnPointHistories.get(1).updateMillis());
     }
+
     @Test
     @DisplayName("id가 양수인지 확인하는 테스트")
     void 사용자포인트_id_양수_아니면_에러() {
@@ -156,5 +157,16 @@ public class PointServiceTest {
         assertThrows(IllegalArgumentException.class, () -> new UserPoint(id1, amount, updateMillis));
         assertThrows(IllegalArgumentException.class, () -> new UserPoint(id2, amount, updateMillis));
     }
+
+    @Test
+    @DisplayName("충전 시 포인트가 양수가 아닐 때 에러 발생")
+    void 충전_시_포인트는_양수_아닐때_에러() {
+        long id = 1L;
+        long amount = -1L;
+        long updateMillis = 0L;
+
+        assertThrows(IllegalArgumentException.class, () -> new UserPoint(id, amount, updateMillis));
+    }
+
 
 }

--- a/src/test/java/io/hhplus/tdd/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/PointServiceTest.java
@@ -146,6 +146,4 @@ public class PointServiceTest {
         assertEquals(insertedPointHistory2.updateMillis(), returnPointHistories.get(1).updateMillis());
     }
 
-
-
 }

--- a/src/test/java/io/hhplus/tdd/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/PointServiceTest.java
@@ -167,5 +167,14 @@ public class PointServiceTest {
         assertThrows(IllegalArgumentException.class, () -> pointService.charge(id, amount));
     }
 
+    @Test
+    @DisplayName("사용 시 포인트가 양수가 아닐 때 에러 발생")
+    void 사용_시_포인트는_양수_아닐때_에러() {
+        long id = 1L;
+        long amount = -1L;
+
+        assertThrows(IllegalArgumentException.class, () -> pointService.use(id, amount));
+    }
+
 
 }

--- a/src/test/java/io/hhplus/tdd/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/PointServiceTest.java
@@ -57,23 +57,35 @@ public class PointServiceTest {
         long beforeUpdateMillis = 0L;
         long afterUpdateMillis = 1L;
 
-        // 충전 내역
+
+        UserPoint beforeUserPoint = new UserPoint(id, beforeAmount, beforeUpdateMillis);
+        UserPoint chargedUserPoint = new UserPoint(id, beforeAmount + chargeAmount, afterUpdateMillis);
+
+
+        doReturn(beforeUserPoint).when(userPointTable).selectById(id);
+        doReturn(chargedUserPoint).when(userPointTable).insertOrUpdate(id, beforeAmount + chargeAmount);
+
+
+        UserPoint returnUserPoint = pointService.charge(id, chargeAmount);
+
+        assertEquals(returnUserPoint.id(), chargedUserPoint.id());
+        assertEquals(returnUserPoint.point(), chargedUserPoint.point());
+        assertEquals(returnUserPoint.updateMillis(), chargedUserPoint.updateMillis());
+    }
+
+    @Test
+    @DisplayName("특정 id에 포인트 충전/사용 시 내역이 저장된다.")
+    void 포인트_충전_시_내역_저장() {
+
+        long id = 1L;
+        long chargeAmount = 50L;
+
         PointHistory insertedPointHistory = new PointHistory(1L, id, chargeAmount, TransactionType.CHARGE, System.currentTimeMillis());
         List<PointHistory> userHistories = new ArrayList<>();
         userHistories.add(insertedPointHistory);
 
-        // 포인트
-        UserPoint beforeUserPoint = new UserPoint(id, beforeAmount, beforeUpdateMillis);
-        UserPoint chargedUserPoint = new UserPoint(id, beforeAmount + chargeAmount, afterUpdateMillis);
-
-        // 충전 내역
         doReturn(userHistories).when(pointHistoryTable).selectAllByUserId(id);
 
-        // 포인트
-        doReturn(beforeUserPoint).when(userPointTable).selectById(id);
-        doReturn(chargedUserPoint).when(userPointTable).insertOrUpdate(id, beforeAmount + chargeAmount);
-
-        // 충전 내역
         List<PointHistory> returnPointHistories = pointService.selectAllByUserId(1L);
 
         assertEquals(1, returnPointHistories.size());
@@ -82,15 +94,8 @@ public class PointServiceTest {
         assertEquals(insertedPointHistory.amount(), returnPointHistories.get(0).amount());
         assertEquals(insertedPointHistory.type(), returnPointHistories.get(0).type());
         assertEquals(insertedPointHistory.updateMillis(), returnPointHistories.get(0).updateMillis());
-
-        // 포인트
-        UserPoint returnUserPoint = pointService.charge(id, chargeAmount);
-
-        assertEquals(returnUserPoint.id(), chargedUserPoint.id());
-        assertEquals(returnUserPoint.point(), chargedUserPoint.point());
-        assertEquals(returnUserPoint.updateMillis(), chargedUserPoint.updateMillis());
     }
 
-
+    
 
 }

--- a/src/test/java/io/hhplus/tdd/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/PointServiceTest.java
@@ -1,0 +1,46 @@
+package io.hhplus.tdd;
+
+import io.hhplus.tdd.database.PointHistoryTable;
+import io.hhplus.tdd.database.UserPointTable;
+import io.hhplus.tdd.point.PointService;
+import io.hhplus.tdd.point.UserPoint;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+public class PointServiceTest {
+
+    @InjectMocks
+    private PointService pointService;
+    @Mock
+    private UserPointTable userPointTable;
+    @Mock
+    private PointHistoryTable pointHistoryTable;
+
+    @Test
+    @DisplayName("id로 포인트 조회")
+    void 포인트_조회() {
+        long id = 1L;
+        long amount = 100L;
+        long updateMillis = 0L;
+
+        UserPoint userPoint = new UserPoint(id, amount, updateMillis);
+
+        doReturn(new UserPoint(id, amount, updateMillis)).when(userPointTable).selectById(id);
+
+        UserPoint returnUserPoint = pointService.selectById(id);
+
+        assertEquals(returnUserPoint.point(), userPoint.point());
+        assertEquals(returnUserPoint.id(), userPoint.id());
+        assertEquals(returnUserPoint.updateMillis(), userPoint.updateMillis());
+    }
+
+
+}

--- a/src/test/java/io/hhplus/tdd/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/PointServiceTest.java
@@ -23,6 +23,8 @@ public class PointServiceTest {
     @InjectMocks
     private PointService pointService;
     @Mock
+    private LockManager lockManager;
+    @Mock
     private UserPointTable userPointTable;
     @Mock
     private PointHistoryTable pointHistoryTable;

--- a/src/test/java/io/hhplus/tdd/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/PointServiceTest.java
@@ -111,4 +111,41 @@ public class PointServiceTest {
         assertThrows(IllegalArgumentException.class, () -> pointService.use(id, amount + 1L));
     }
 
+    @Test
+    @DisplayName("특정 id로 포인트 충전/사용 이력 조회")
+    void 포인트_사용_충전_이력_조회() {
+        long historyId = 1L;
+        long userId = 2L;
+        long amount1 = 200L;
+        long amount2 = 100L;
+        long updateMillis1 = 1L;
+        long updateMillis2 = 2L;
+
+
+        PointHistory insertedPointHistory1 = new PointHistory(historyId, userId, amount1, TransactionType.CHARGE, updateMillis1);
+        PointHistory insertedPointHistory2 = new PointHistory(historyId + 1, userId, amount2, TransactionType.USE, updateMillis2);
+        List<PointHistory> userHistories = new ArrayList<>();
+        userHistories.add(insertedPointHistory1);
+        userHistories.add(insertedPointHistory2);
+
+        doReturn(userHistories).when(pointHistoryTable).selectAllByUserId(userId);
+
+        List<PointHistory> returnPointHistories = pointService.selectAllByUserId(userId);
+
+        assertEquals(2, returnPointHistories.size());
+        assertEquals(insertedPointHistory1.id(), returnPointHistories.get(0).id());
+        assertEquals(insertedPointHistory1.userId(), returnPointHistories.get(0).userId());
+        assertEquals(insertedPointHistory1.amount(), returnPointHistories.get(0).amount());
+        assertEquals(insertedPointHistory1.type(), returnPointHistories.get(0).type());
+        assertEquals(insertedPointHistory1.updateMillis(), returnPointHistories.get(0).updateMillis());
+
+        assertEquals(insertedPointHistory2.id(), returnPointHistories.get(1).id());
+        assertEquals(insertedPointHistory2.userId(), returnPointHistories.get(1).userId());
+        assertEquals(insertedPointHistory2.amount(), returnPointHistories.get(1).amount());
+        assertEquals(insertedPointHistory2.type(), returnPointHistories.get(1).type());
+        assertEquals(insertedPointHistory2.updateMillis(), returnPointHistories.get(1).updateMillis());
+    }
+
+
+
 }

--- a/src/test/java/io/hhplus/tdd/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/PointServiceTest.java
@@ -163,9 +163,8 @@ public class PointServiceTest {
     void 충전_시_포인트는_양수_아닐때_에러() {
         long id = 1L;
         long amount = -1L;
-        long updateMillis = 0L;
 
-        assertThrows(IllegalArgumentException.class, () -> new UserPoint(id, amount, updateMillis));
+        assertThrows(IllegalArgumentException.class, () -> pointService.charge(id, amount));
     }
 
 

--- a/src/test/java/io/hhplus/tdd/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/PointServiceTest.java
@@ -2,7 +2,9 @@ package io.hhplus.tdd;
 
 import io.hhplus.tdd.database.PointHistoryTable;
 import io.hhplus.tdd.database.UserPointTable;
+import io.hhplus.tdd.point.PointHistory;
 import io.hhplus.tdd.point.PointService;
+import io.hhplus.tdd.point.TransactionType;
 import io.hhplus.tdd.point.UserPoint;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,6 +12,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.doReturn;
@@ -37,10 +42,55 @@ public class PointServiceTest {
 
         UserPoint returnUserPoint = pointService.selectById(id);
 
-        assertEquals(returnUserPoint.point(), userPoint.point());
         assertEquals(returnUserPoint.id(), userPoint.id());
+        assertEquals(returnUserPoint.point(), userPoint.point());
         assertEquals(returnUserPoint.updateMillis(), userPoint.updateMillis());
     }
+
+    @Test
+    @DisplayName("특정 id에 포인트 충전 시 내역이 저장되고 포인트도 충전된다.")
+    void 포인트_충전() {
+
+        long id = 1L;
+        long beforeAmount = 100L;
+        long chargeAmount = 50L;
+        long beforeUpdateMillis = 0L;
+        long afterUpdateMillis = 1L;
+
+        // 충전 내역
+        PointHistory insertedPointHistory = new PointHistory(1L, id, chargeAmount, TransactionType.CHARGE, System.currentTimeMillis());
+        List<PointHistory> userHistories = new ArrayList<>();
+        userHistories.add(insertedPointHistory);
+
+        // 포인트
+        UserPoint beforeUserPoint = new UserPoint(id, beforeAmount, beforeUpdateMillis);
+        UserPoint chargedUserPoint = new UserPoint(id, beforeAmount + chargeAmount, afterUpdateMillis);
+
+        // 충전 내역
+        doReturn(userHistories).when(pointHistoryTable).selectAllByUserId(id);
+
+        // 포인트
+        doReturn(beforeUserPoint).when(userPointTable).selectById(id);
+        doReturn(chargedUserPoint).when(userPointTable).insertOrUpdate(id, beforeAmount + chargeAmount);
+
+        // 충전 내역
+        List<PointHistory> returnPointHistories = pointService.selectAllByUserId(1L);
+
+        assertEquals(1, returnPointHistories.size());
+        assertEquals(insertedPointHistory.id(), returnPointHistories.get(0).id());
+        assertEquals(insertedPointHistory.userId(), returnPointHistories.get(0).userId());
+        assertEquals(insertedPointHistory.amount(), returnPointHistories.get(0).amount());
+        assertEquals(insertedPointHistory.type(), returnPointHistories.get(0).type());
+        assertEquals(insertedPointHistory.updateMillis(), returnPointHistories.get(0).updateMillis());
+
+        // 포인트
+        UserPoint returnUserPoint = pointService.charge(id, chargeAmount);
+
+        assertEquals(returnUserPoint.id(), chargedUserPoint.id());
+        assertEquals(returnUserPoint.point(), chargedUserPoint.point());
+        assertEquals(returnUserPoint.updateMillis(), chargedUserPoint.updateMillis());
+    }
+
 
 
 }

--- a/src/test/java/io/hhplus/tdd/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/PointServiceTest.java
@@ -145,5 +145,16 @@ public class PointServiceTest {
         assertEquals(insertedPointHistory2.type(), returnPointHistories.get(1).type());
         assertEquals(insertedPointHistory2.updateMillis(), returnPointHistories.get(1).updateMillis());
     }
+    @Test
+    @DisplayName("id가 양수인지 확인하는 테스트")
+    void 사용자포인트_id_양수_아니면_에러() {
+        long id1 = -1L;
+        long id2 = 0L;
+        long amount = 100L;
+        long updateMillis = 0L;
+
+        assertThrows(IllegalArgumentException.class, () -> new UserPoint(id1, amount, updateMillis));
+        assertThrows(IllegalArgumentException.class, () -> new UserPoint(id2, amount, updateMillis));
+    }
 
 }

--- a/src/test/java/io/hhplus/tdd/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/PointServiceTest.java
@@ -2,10 +2,7 @@ package io.hhplus.tdd;
 
 import io.hhplus.tdd.database.PointHistoryTable;
 import io.hhplus.tdd.database.UserPointTable;
-import io.hhplus.tdd.point.PointHistory;
-import io.hhplus.tdd.point.PointService;
-import io.hhplus.tdd.point.TransactionType;
-import io.hhplus.tdd.point.UserPoint;
+import io.hhplus.tdd.point.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,9 +12,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -179,37 +173,4 @@ public class PointServiceTest {
         assertThrows(IllegalArgumentException.class, () -> pointService.use(id, amount));
     }
 
-    @Test
-    @DisplayName("같은 id로 요청이 100번 있을 때 빠짐없이 처리되는지 테스트")
-    void 여러번_반복_충전_시_누락없이_처리되는지_테스트() throws InterruptedException {
-
-        long id = 1L;
-        long addAmount = 100L;
-
-        // given
-        final int threadCount = 100;
-        final int threadPoolSize = 32;
-
-        final ExecutorService executorService = Executors.newFixedThreadPool(threadPoolSize);
-        final CountDownLatch countDownLatch = new CountDownLatch(threadCount);
-
-        pointService.charge(id, addAmount);
-
-        // when
-        for (int i = 0; i < threadCount; i++) {
-            executorService.submit(() -> {
-                try {
-                    pointService.use(id, 1L);
-                } finally {
-                    countDownLatch.countDown();
-                }
-            });
-        }
-        countDownLatch.await();
-
-        UserPoint resultUser = pointService.selectById(id);
-
-        // then
-        assertEquals(9899, resultUser.point());
-    }
 }


### PR DESCRIPTION
**작업 내용**

- 비동기로 처리되도록 수정했습니다.
- 비동기로 처리하도록 연속 100회 요청을 날리고 정상적으로 처리되는지 테스트했습니다.

**의사결정흐름** 
포인트가 변경되는 경우에 락을 이용하여 공유자원에 동시에 접근하지 못하도록 하기 위해
id별로 락을 관리할 수 있도록 ReentrantLock을 사용했습니다.